### PR TITLE
Improve linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-- '5.0'
+- '6.9'
 - 'stable'
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ deploy:
     branch: master
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
-    tags: false
+    tags: true
 notifications:
   slack:
     secure: dG4SEytJdfHDgvZz6g1piFhnPHAUstVNm8tgotfZqqjVEtqYWMdm9Ib31csuRIYnvZUIEFEcrygLsq1ZMac3hoBzBR9i6Y1Mf/LJqPTRl4++CE/p/DlRZ8a4cZUJpNCTtV8mf9h1zXyj5PJkaO2ZHdVFszcsmEfVDOVb8s27+uj03xC7Ir1Qqyzsd1QCiBEY//lry/0AwCslTZz6tXCz4e2wojbB+L6/+U1frAZqKG7jiHC7j0a9uQkNsfb8W8xyWrdJKpX9SWxqzpiJF8afYfvtVy7uNYzmVmaCsq4RrwjI17dFVBAtSAsWWir4JpHH0GNBzpd1QwvHxcmUnKV39KACu4Z9PLLzITNb71YNbez+CpvgJf2CcymwhxdlAW4qVcznO+QaC5wTcFrUKaVOFNc0TPWfX+WjPK+aG9uOTVrkG+BQolE9tG8l3V29A1kKEDK/+BKwiq4YGVGQEHDAg9a/MdYhCY73O98IWxxgHoYF85x+xRjBaGoulNGTLi5FLPVQYtmP3m+PTQGu3KxoaKN4oS8Kk90s/45ER8m39i181OhaJzoIEKz6MVicjNhL2i0ayCLHdLfPBWHgXYhmEcO7RHGpgPl1XZYpN3ZRESszhS5WHvfRhZDriHddersF5dTzmJBEpXZEKYbeMwEQyECikgeJKuaFRoId2LyBmRA=

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
   },
   "scripts": {
     "build": "ember build",
-    "lint": "npm run lint-js && npm run lint-md",
-    "lint-js": "eslint *.js addon app blueprints config tests",
-    "lint-md": "remark *.md",
+    "lint": "lint-all-the-things",
     "start": "ember server",
     "test": "npm run lint && ember test"
   },
@@ -42,12 +40,8 @@
     "ember-export-application-global": "^1.1.1",
     "ember-load-initializers": "0.6.3",
     "ember-resolver": "^2.1.1",
-    "ember-test-utils": "^1.8.0",
-    "eslint": "^3.13.1",
-    "eslint-config-frost-standard": "^5.3.2",
+    "ember-test-utils": "^1.10.3",
     "loader.js": "^4.1.0",
-    "remark-cli": "^2.1.0",
-    "remark-lint": "^5.4.0",
     "validator": "6.2.1"
   },
   "keywords": [


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Updated** Travis to only publish when git tags are added in preparation for non-version bump pull requests.
* **Updated** linting to use linting tools from `ember-test-utils`.
