### PR TITLE
upgrade ember-cli to 2.12.3

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
-{
-  "extends": ["frost-standard"],
+module.exports = {
+  extends: 'frost-standard',
   "rules": {
     "ocd/sort-import-declarations": [
       2,
@@ -13,4 +13,4 @@
       }
     ]
   }
-}
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,7 @@
+/*
+  The localPrefix listed below with "validator" is in place because this module is exported with a
+  different name than the addon and our default rule would add the addon name which we do not want in this case.
+ */
 module.exports = {
   extends: 'frost-standard',
   "rules": {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,4 +13,4 @@ module.exports = {
       }
     ]
   }
-};
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
 /dist
@@ -13,6 +13,6 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
-npm-debug.log
+npm-debug.log*
 testem.log
 /typings/*

--- a/.npmignore
+++ b/.npmignore
@@ -8,11 +8,9 @@
 .editorconfig
 .ember-cli
 .eslintignore
-.eslintrc
+.eslintrc.js
 .github
 .gitignore
-.jshintrc
-.eslintrc.js
 .pullapprove.yml
 .remarkrc
 .travis

--- a/.npmignore
+++ b/.npmignore
@@ -12,6 +12,7 @@
 .github
 .gitignore
 .jshintrc
+.eslintrc.js
 .pullapprove.yml
 .remarkrc
 .travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,12 @@ cache:
 
 env:
   matrix:
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-default
+  - EMBER_TRY_SCENARIO=ember-release
+  - EMBER_TRY_SCENARIO=ember-beta
+  - EMBER_TRY_SCENARIO=ember-canary
   global:
     - CXX=g++-4.8
     - secure: Psmz9EtEiwUCY7aMVQ/zMqKfIvCq7aHKNa5NvIcYeFhr0MEmETTAvKoWqKp3+M01wvtNzFFUaINr1Tu0juWf8zcrDLrqbaCYe3fcjb8LGMpz5P6U1bMvhtfgI4+jaDV1c7bgHEnjhpPw2ylpNNulvUbClLQLx2swHwJUAtvEP08qWgMQ+v4aiip2SKg81z0oKAN6qUbiNVcydx4HZ4gEfHQ28Ee/EDggUu7mVLINKRalMf1QDA+yA9TFAiVepkwpHjvVwKnEL1K4WTQ0K5CZ0EWw1JSuHy8xGd8ACbd7+abkdXoae2KdACVx/HxfuXG/oWxhVtX7dOqpqzrn15fqRMBpVV/fuQjgfPi687aaqXTQwx/At9V6IQmJnacqMKyO5EQNepFMYbZeD7J1yxImcuFfzQTfScUJl9SWFgjyzJ0tUHZdilWh3f+Jtdq9IO8wP9Db51207GHJPXvRr2RLD6tL43KNHftUzK9SYZ5OKC2kxZDa0Z4I/gQKtb6Dxg4BKIHSXKvkmvURf8NYqGnIk8IvrnkIhxQoWPhgcNQB0mg6wJBdGWh+cm9A5vZ7McX6wuppVJsMH0kF53S8khLPmMp7mGO0J9+4Y2xnvidO/F33ydV77vU+mTLO3JPbjyj/zQsy+HnhIMEDdGzX9/1EKm+9ZaCKQBlr3PNWQuqp9uA=
@@ -31,25 +35,30 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+  - env: EMBER_TRY_SCENARIO=ember-release
   - env: EMBER_TRY_SCENARIO=ember-beta
   - env: EMBER_TRY_SCENARIO=ember-canary
   - node_js: 'stable'
-  
+
 before_install:
-- "export DISPLAY=:99.0"
-- "sh -e /etc/init.d/xvfb start"
-- npm config set spin false
-- npm install -g coveralls pr-bumper
+  - npm config set spin false
+  - npm install -g coveralls pr-bumper@^1.0.0
+  - $(npm root -g)/pr-bumper/.travis/maybe-check-scope.sh
 
 install:
-- $(npm root -g)/pr-bumper/.travis/maybe-install.sh
+  - $(npm root -g)/pr-bumper/.travis/maybe-install.sh
+
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 
 script:
-- $(npm root -g)/pr-bumper/.travis/maybe-test.sh
-- if [ $EMBER_TRY_SCENARIO == "default" ]; then $(npm root -g)/pr-bumper/.travis/maybe-bump-version.sh; fi
+  - $(npm root -g)/pr-bumper/.travis/maybe-test.sh
+  - .travis/maybe-bump-version.sh
 
 after_success:
-- $(npm root -g)/pr-bumper/.travis/maybe-publish-coverage.sh
+  - .travis/maybe-publish-coverage.sh
 
 deploy:
   provider: npm
@@ -60,7 +69,7 @@ deploy:
   on:
     all_branches: true
     condition: "$EMBER_TRY_SCENARIO = 'ember-default'"
-    node: 'stable'
+    node: '6.9.1'
     tags: true
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ matrix:
   allow_failures:
   - env: EMBER_TRY_SCENARIO=ember-beta
   - env: EMBER_TRY_SCENARIO=ember-canary
-
+  - node_js: 'stable'
+  
 before_install:
 - "export DISPLAY=:99.0"
 - "sh -e /etc/init.d/xvfb start"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,8 @@ cache:
 
 env:
   matrix:
-  - EMBER_TRY_SCENARIO=ember-1-12
-  - EMBER_TRY_SCENARIO=ember-2-8
-  - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
+  - EMBER_TRY_SCENARIO=ember-lts-2.8
+  - EMBER_TRY_SCENARIO=ember-default
   global:
     - CXX=g++-4.8
     - secure: Psmz9EtEiwUCY7aMVQ/zMqKfIvCq7aHKNa5NvIcYeFhr0MEmETTAvKoWqKp3+M01wvtNzFFUaINr1Tu0juWf8zcrDLrqbaCYe3fcjb8LGMpz5P6U1bMvhtfgI4+jaDV1c7bgHEnjhpPw2ylpNNulvUbClLQLx2swHwJUAtvEP08qWgMQ+v4aiip2SKg81z0oKAN6qUbiNVcydx4HZ4gEfHQ28Ee/EDggUu7mVLINKRalMf1QDA+yA9TFAiVepkwpHjvVwKnEL1K4WTQ0K5CZ0EWw1JSuHy8xGd8ACbd7+abkdXoae2KdACVx/HxfuXG/oWxhVtX7dOqpqzrn15fqRMBpVV/fuQjgfPi687aaqXTQwx/At9V6IQmJnacqMKyO5EQNepFMYbZeD7J1yxImcuFfzQTfScUJl9SWFgjyzJ0tUHZdilWh3f+Jtdq9IO8wP9Db51207GHJPXvRr2RLD6tL43KNHftUzK9SYZ5OKC2kxZDa0Z4I/gQKtb6Dxg4BKIHSXKvkmvURf8NYqGnIk8IvrnkIhxQoWPhgcNQB0mg6wJBdGWh+cm9A5vZ7McX6wuppVJsMH0kF53S8khLPmMp7mGO0J9+4Y2xnvidO/F33ydV77vU+mTLO3JPbjyj/zQsy+HnhIMEDdGzX9/1EKm+9ZaCKQBlr3PNWQuqp9uA=
@@ -62,7 +58,7 @@ deploy:
     secure: NWWCQl+qvz7MV+RzKYPMdPHvSga6LGZ0SUIQ91PzpzeAmcJoRFdEbboTojShbQnT3gxirOaaJypj6zstxb1uu++uXBeweh5Sz+eUKFWSfoi8y4Xk1K2DtPrOn+Gaw6syQENZgjAo+EY16WIGdVIZKJdjVI/AJ7mEK48tnTLn5Cd11ifZfuvjVKHgAhXOHC7ovtXbk0cbMznvxfQwY+hhjemCFZcBSBf7WsUf16zybanYigOwDMVVD2Rk0htS9Gyrzkvqx9hrpC3J8lemR4rsUHz5v4Qi8nruKr+BytLlkNoK3oQdQnIzINd3diGuqNsyaIwbrWEot0jUU+CUwNKf878f0/3tnGfryio2IGOuQICcvLP33wcDe/s7r86f+km5TlpOXXoBlazSZdpB/GpdIgoTgqN4UMkTGslwZfkG3dye28zwcPKf27BK9QoKVTryi75uBtfM0N59aUJJWRCMGT3cpwn8YmgLWl0IL4ItJrrgQenLd3Bix6mNJP2ebYbxp9Yug+xevVW1LcehUOrP48Ar3DaXbnR8npCdw3V4OJ3WMQtm1xaHWpFVIerbgpxfvPTsxEzhowinu+UaJ1oQksZiKNNTfNSSpbFnEmxZwr1YcDwoLVtZFqLJVRmue2nkuiAnp4H7rjv0ydMuZa9I6+Ham0weunEeYglrsGHnD/M=
   on:
     all_branches: true
-    condition: "$EMBER_TRY_SCENARIO = 'default'"
+    condition: "$EMBER_TRY_SCENARIO = 'ember-default'"
     node: 'stable'
     tags: true
 

--- a/.travis/maybe-bump-version.sh
+++ b/.travis/maybe-bump-version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ "$TRAVIS_NODE_VERSION" != "6.9.1" ]
+then
+  echo "Skipping version bump for TRAVIS_NODE_VERSION ${TRAVIS_NODE_VERSION}"
+  exit 0
+fi
+
+if [ "$EMBER_TRY_SCENARIO" != "ember-default" ]
+then
+  echo "Skipping version bump for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"
+  exit 0
+fi
+
+$(npm root -g)/pr-bumper/.travis/maybe-bump-version.sh

--- a/.travis/maybe-publish-coverage.sh
+++ b/.travis/maybe-publish-coverage.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+source $(npm root -g)/pr-bumper/.travis/is-bump-commit.sh
+
+if isBumpCommit
+then
+  echo "Skipping coverage publish for version bump commit"
+  exit 0
+fi
+
+if [ "$TRAVIS_NODE_VERSION" != "6.9.1" ]
+then
+  echo "Skipping coverage publish for TRAVIS_NODE_VERSION ${TRAVIS_NODE_VERSION}"
+  exit 0
+fi
+
+if [ "$EMBER_TRY_SCENARIO" != "ember-default" ]
+then
+  echo "Skipping coverage publish for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"
+  exit 0
+fi
+
+cat coverage/lcov.info | coveralls

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,5 @@
 {
   "name": "ember-validator-shim",
   "dependencies": {
-    "ember": "^2.11.0",
-    "ember-cli-shims": "0.1.1",
-    "ember-mocha": "0.8.11"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,151 +1,35 @@
+/* eslint-env node */
 module.exports = {
   scenarios: [
     {
-      name: 'default',
-      bower: {
-        dependencies: { }
-      }
-    },
-    {
-      name: 'ember-1-12',
+      name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          'ember': '~1.12.0'
+          'ember': 'components/ember#lts-2-8'
         },
         resolutions: {
-          'ember': '~1.12.0'
+          'ember': 'lts-2-8'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
     {
-      name: 'ember-1-13',
+      name: 'ember-lts-2.12',
       bower: {
         dependencies: {
-          'ember': '~1.13.0'
+          'ember': 'components/ember#lts-2-12'
         },
         resolutions: {
-          'ember': '~1.13.0'
+          'ember': 'lts-2-12'
         }
-      }
-    },
-    {
-      name: 'ember-2-0',
-      bower: {
-        dependencies: {
-          'ember': '~2.0.0'
-        },
-        resolutions: {
-          'ember': '~2.0.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-1',
-      bower: {
-        dependencies: {
-          'ember': '~2.1.0'
-        },
-        resolutions: {
-          'ember': '~2.1.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-2',
-      bower: {
-        dependencies: {
-          'ember': '~2.2.0'
-        },
-        resolutions: {
-          'ember': '~2.2.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-3',
-      bower: {
-        dependencies: {
-          'ember': '~2.3.0'
-        },
-        resolutions: {
-          'ember': '~2.3.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-4',
-      bower: {
-        dependencies: {
-          'ember': '~2.4.0'
-        },
-        resolutions: {
-          'ember': '~2.4.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-5',
-      bower: {
-        dependencies: {
-          'ember': '~2.5.0'
-        },
-        resolutions: {
-          'ember': '~2.5.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-6',
-      bower: {
-        dependencies: {
-          'ember': '~2.6.0'
-        },
-        resolutions: {
-          'ember': '~2.6.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-7',
-      bower: {
-        dependencies: {
-          'ember': '~2.7.0'
-        },
-        resolutions: {
-          'ember': '~2.7.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-8',
-      bower: {
-        dependencies: {
-          'ember': '~2.8.0'
-        },
-        resolutions: {
-          'ember': '~2.8.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-9',
-      bower: {
-        dependencies: {
-          'ember': '~2.9.0'
-        },
-        resolutions: {
-          'ember': '~2.9.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-10',
-      bower: {
-        dependencies: {
-          'ember': '~2.10.0'
-        },
-        resolutions: {
-          'ember': '~2.10.0'
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -158,6 +42,11 @@ module.exports = {
         resolutions: {
           'ember': 'release'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -168,6 +57,11 @@ module.exports = {
         },
         resolutions: {
           'ember': 'beta'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -180,6 +74,17 @@ module.exports = {
         resolutions: {
           'ember': 'canary'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-default',
+      npm: {
+        devDependencies: {}
       }
     }
   ]

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,6 +2,22 @@
 module.exports = {
   scenarios: [
     {
+      name: 'ember-lts-2.4',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#lts-2-4'
+        },
+        resolutions: {
+          'ember': 'lts-2-4'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
       name: 'ember-lts-2.8',
       bower: {
         dependencies: {
@@ -89,3 +105,4 @@ module.exports = {
     }
   ]
 }
+

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 'use strict'
 
 module.exports = function (/* environment, appConfig */) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* global require, module */
+/* eslint-env node */
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon')
 
 module.exports = function (defaults) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,5 +1,5 @@
 /* eslint-env node */
-var EmberAddon = require('ember-cli/lib/broccoli/ember-addon')
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon')
 
 module.exports = function (defaults) {
   var app = new EmberAddon(defaults, {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-
+/* eslint-env node */
 'use strict'
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "validator"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.9",
-    "ember-cli-htmlbars": "^1.1.0"
+    "ember-cli-babel": "^5.1.7",
+    "ember-cli-htmlbars": "^1.1.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "lint-all-the-things",
     "start": "ember server",
     "test": "npm run lint && npm run test-addon",
-    "test-addon": "EMBER_TRY_SCENARIO=${EMBER_TRY_SCENARIO:=default} && ember try:one $EMBER_TRY_SCENARIO --- COVERAGE=true ember test"
+    "test-addon": "EMBER_TRY_SCENARIO=${EMBER_TRY_SCENARIO:=ember-default} && ember try:one $EMBER_TRY_SCENARIO --- COVERAGE=true ember test"
   },
   "repository": {
     "type": "git",
@@ -27,22 +27,24 @@
   "author": "Matthew Dahl (https://github.com/sandersky)",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.5.0",
-    "ember-cli": "^2.11.0",
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-cli": "2.12.3",
     "ember-cli-app-version": "^2.0.1",
     "ember-cli-chai": "^0.3.2",
     "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-htmlbars-inline-precompile": "0.3.6",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mocha": "0.13.2",
+    "ember-cli-shims": "^1.0.2",
     "ember-cli-test-loader": "^1.1.1",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-export-application-global": "^1.1.1",
-    "ember-load-initializers": "0.6.3",
+    "ember-export-application-global": "^1.0.5",
+    "ember-load-initializers": "^0.6.0",
+    "ember-source": "~2.12.0",
     "ember-resolver": "^2.1.1",
     "ember-test-utils": "^1.10.3",
-    "loader.js": "^4.1.0"
+    "loader.js": "^4.2.3"
   },
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "2.12.3",
-    "ember-cli-app-version": "^2.0.1",
     "ember-cli-chai": "^0.3.2",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.6",
@@ -42,7 +41,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
     "ember-source": "~2.12.0",
-    "ember-resolver": "^2.1.1",
+    "ember-resolver": "^2.0.3",
     "ember-test-utils": "^1.10.3",
     "loader.js": "^4.2.3"
   },

--- a/testem.js
+++ b/testem.js
@@ -1,5 +1,5 @@
+/* eslint-env node */
 var Reporter = require('ember-test-utils/reporter')
-
 module.exports = {
   disable_watching: true,
   framework: 'mocha',

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,9 +1,0 @@
-{
-  "globals": {
-    "chai": false,
-    "Ember": false,
-    "find": false,
-    "pauseTest": false,
-    "sinon": false
-  }
-}

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    embertest: true
+  }
+};

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -2,4 +2,4 @@ module.exports = {
   env: {
     embertest: true
   }
-};
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -4,7 +4,8 @@ const {Router: EmberRouter} = Ember
 import config from './config/environment'
 
 const Router = EmberRouter.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 })
 
 Router.map(function () {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,32 +1,49 @@
 /* eslint-env node */
+
 module.exports = function (environment) {
   var ENV = {
-    APP: {},
+    modulePrefix: 'dummy',
+    environment: environment,
     rootURL: '/',
+    locationType: 'hash',
     EmberENV: {
-      FEATURES: {},
+      FEATURES: {
+        // Here you can enable experimental features on an ember canary build
+        // e.g. 'with-controller': true
+      },
       EXTEND_PROTOTYPES: {
         // Prevent Ember Data from overriding Date.parse.
         Date: false
       }
     },
-    environment: environment,
-    locationType: 'hash',
-    modulePrefix: 'dummy'
+
+    APP: {
+      // Here you can pass flags/options to your application instance
+      // when it is created
+    }
   }
 
-  switch (environment) {
-    case 'test':
-      // Testem prefers this...
-      ENV.rootURL = '/'
-      ENV.locationType = 'none'
+  if (environment === 'development') {
+    // ENV.APP.LOG_RESOLVER = true;
+    // ENV.APP.LOG_ACTIVE_GENERATION = true;
+    // ENV.APP.LOG_TRANSITIONS = true;
+    // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
+    // ENV.APP.LOG_VIEW_LOOKUPS = true;
+  }
 
-      // keep test console output quieter
-      ENV.APP.LOG_ACTIVE_GENERATION = false
-      ENV.APP.LOG_VIEW_LOOKUPS = false
+  if (environment === 'test') {
+    // Testem prefers this...
+    ENV.locationType = 'none'
 
-      ENV.APP.rootElement = '#ember-testing'
-      break
+    // keep test console output quieter
+    ENV.APP.LOG_ACTIVE_GENERATION = false
+    ENV.APP.LOG_VIEW_LOOKUPS = false
+
+    ENV.APP.rootElement = '#ember-testing'
+  }
+
+  if (environment === 'production') {
+
   }
 
   return ENV

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,9 +1,14 @@
+/* eslint-env node */
 module.exports = function (environment) {
   var ENV = {
     APP: {},
     rootURL: '/',
     EmberENV: {
-      FEATURES: {}
+      FEATURES: {},
+      EXTEND_PROTOTYPES: {
+        // Prevent Ember Data from overriding Date.parse.
+        Date: false
+      }
     },
     environment: environment,
     locationType: 'hash',

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -5,16 +5,13 @@ import Application from '../../app'
 import config from '../../config/environment'
 
 export default function startApp (attrs) {
-  let application
-
   let attributes = merge({}, config.APP)
   attributes = merge(attributes, attrs) // use defaults, but you can override;
 
-  run(() => {
-    application = Application.create(attributes)
+  return run(() => {
+    let application = Application.create(attributes)
     application.setupForTesting()
     application.injectTestHelpers()
+    return application
   })
-
-  return application
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,7 +21,7 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="{{rootURL}}testem.js" integrity=""></script>
+    <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/dummy.js"></script>


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

Upgrade Ember-cli to 2.12.3
