### PR TITLE
Fix included binding

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@
 module.exports = {
   name: 'validator',
 
-  included (parent) {
-    this._super.included(parent)
+  included () {
+    this._super.included.apply(this, arguments)
 
     this.import({
       development: 'vendor/validator/validator.js',

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "author": "Matthew Dahl (https://github.com/sandersky)",
   "license": "MIT",
   "devDependencies": {
+    "bower": "^1.8.2",
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "2.12.3",
     "ember-cli-chai": "^0.3.2",
@@ -40,8 +41,8 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
-    "ember-source": "~2.12.0",
     "ember-resolver": "^2.0.3",
+    "ember-source": "~2.12.0",
     "ember-test-utils": "^1.10.3",
     "loader.js": "^4.2.3"
   },


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Closes: https://github.com/ciena-blueplanet/ember-validator-shim/issues/52

# CHANGELOG
* **Updated** binding of _super call inside `included` hook of `index.js`